### PR TITLE
wu.range: incr < 1

### DIFF
--- a/lib/wu.js
+++ b/lib/wu.js
@@ -655,9 +655,9 @@
             start :
             throwNewTypeError("The `start` parameter to wu.range must be a number.");
         incr = toObjProtoString(incr) === OBJECT_NUMBER_STR && !isNaN(incr)
-                && incr !== Infinity && incr !== -Infinity ?
+                && incr !== Infinity && incr !== -Infinity && incr !== 0?
             incr :
-            throwNewTypeError("The `incr` parameter to wu.range must be a number.");
+            throwNewTypeError("The `incr` parameter to wu.range must be a number such that `incr` is not 0.");
         // However, end can be infinite.
         end = toObjProtoString(end) === OBJECT_NUMBER_STR && !isNaN(end) ?
             end :
@@ -667,9 +667,8 @@
         start = start - incr;
 
         return wu.Iterator(function () {
-            return start + incr >= end ?
-                this.stop() :
-                start += incr;
+            return (incr < 0 ? start + incr <= end : start + incr >= end) ?
+                this.stop() : start += incr;
         });
     };
 


### PR DESCRIPTION
allows ranges with negative increments and now throws up on 0 as an incrementor (like the python range)
