### PR TITLE
Fix for issue #25 where zipLongest sometimes returns extra item

### DIFF
--- a/test/test-zipLongest.js
+++ b/test/test-zipLongest.js
@@ -1,12 +1,21 @@
 const wu = require("../wu");
 const assert = require("../assert");
 describe("wu.zipLongest", () => {
-  it("should stop with the longer iterable", () => {
-    const arr1 = [];
-    arr1[1] = 2;
-    const arr2 = [];
-    arr2[1] = 3;
-    assert.eqArray([["a", 1], arr1, arr2],
-                   wu.zipLongest("a", [1, 2, 3]));
+
+  var tests =[
+    {args: ["a", [1,2,3]],              expected: [["a", 1], [,2], [,3]]},
+    {args: [["a"], [1,2,3]],            expected: [["a", 1], [,2], [,3]]},
+    {args: [["a","b","c"], [1,2]],      expected: [["a", 1], ["b",2], ["c", ]]},
+    {args: ["a", [1,2,3], [7,8,9,10]],  expected: [["a", 1, 7], [ , 2, 8], [ , 3, 9], [ , , 10]]},
+    {args: [["a"], [1,2,3,4], [7,8,9]], expected: [["a", 1, 7], [ , 2, 8], [ , 3, 9], [ , 4, ]]}
+  ];
+
+  tests.forEach(test => {
+    it('should stop with the longest iterable', () =>
+    {
+      assert.eqArray(test.expected,
+          wu.zipLongest(...test.args));
+    })
   });
 });
+

--- a/wu.js
+++ b/wu.js
@@ -335,11 +335,10 @@ const _zip = rewrap(function* (iterables, longest=false) {
 
   const iters = iterables.map(getIterator);
   const numIters = iterables.length;
-  let numFinished = 0;
-  let finished = false;
 
-  while (!finished) {
+  while (true) {
     let zipped = [];
+    let numFinished = 0;
 
     for (let it of iters) {
       let { value, done } = it.next();
@@ -348,7 +347,7 @@ const _zip = rewrap(function* (iterables, longest=false) {
           return;
         }
         if (++numFinished == numIters) {
-          finished = true;
+          return;
         }
       }
       if (value === undefined) {


### PR DESCRIPTION
In some cases the zipLongest function would return an extra item containing only undefined elements. This is a fix for that.